### PR TITLE
Report errors for badly-formatted numbers in swagger-validator.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -101,7 +101,7 @@ function convertValue (schema, collectionFormat, value) {
     break;
   case 'integer':
     if (!_.isNumber(value)) {
-      value = parseInt(value, 10);
+      value = Number(value);
 
       if (_.isNaN(value)) {
         throw new TypeError('Not a valid integer: ' + originalValue);
@@ -121,7 +121,7 @@ function convertValue (schema, collectionFormat, value) {
     break;
   case 'number':
     if (!_.isNumber(value)) {
-      value = parseFloat(value);
+      value = Number(value);
 
       if (_.isNaN(value)) {
         throw new TypeError('Not a valid number: ' + originalValue);

--- a/test/test-2.0.js
+++ b/test/test-2.0.js
@@ -3540,5 +3540,79 @@ describe('sway (Swagger 2.0)', function () {
         })
         .then(done, done);
     });
+
+    it('should return an error for number+string "numbers" (Issue )', function (done) {
+      var cSwagger = _.cloneDeep(swaggerDoc);
+
+      cSwagger.paths['/pet/{petId}/friends'] = {
+        parameters: [
+          cSwagger.paths['/pet/{petId}'].parameters[0],
+          {
+            name: 'limit',
+              in: 'query',
+            description: 'Maximum number of friends returned',
+            type: 'number'
+          }
+        ],
+        get: {
+          responses: cSwagger.paths['/pet/{petId}'].get.responses
+        }
+      };
+
+      swaggerApi.create({
+        definition: cSwagger
+      })
+        .then(function (api) {
+          var paramValue = api
+            .getOperation('/pet/{petId}/friends', 'get')
+            .getParameters()[1]
+            .getValue({
+              query: {
+                limit: '2something'
+              }
+            });
+
+          assert.ok(_.isUndefined(paramValue.value));
+          assert.equal(paramValue.error.message, 'Not a valid number: 2something');
+        })
+        .then(done, done);
+    });
+
+    it('should return an error for number+string "integers" (Issue )', function (done) {
+      var cSwagger = _.cloneDeep(swaggerDoc);
+
+      cSwagger.paths['/pet/{petId}/friends'] = {
+        parameters: [
+          cSwagger.paths['/pet/{petId}'].parameters[0],
+          {
+            name: 'limit',
+              in: 'query',
+            description: 'Maximum number of friends returned',
+            type: 'integer'
+          }
+        ],
+        get: {
+          responses: cSwagger.paths['/pet/{petId}'].get.responses
+        }
+      };
+
+      swaggerApi.create({
+        definition: cSwagger
+      })
+        .then(function (api) {
+          var paramValue = api
+            .getOperation('/pet/{petId}/friends', 'get')
+            .getParameters()[1]
+            .getValue({
+              query: {
+                limit: '2something'
+              }
+            });
+
+          assert.ok(_.isUndefined(paramValue.value));
+          assert.equal(paramValue.error.message, 'Not a valid integer: 2something');
+        })
+        .then(done, done);
+    });
   });
 });


### PR DESCRIPTION
_This PR is a port of apigee-127/swagger-tools#279._

Previously, "number" fields with trailing characters (e.g. `2something`) would be coerced to a Number (2). These changes reject those values during validation.

This lacks validation of "decimal" integers, but that seems to me like it's outside the scope of this module. Let me know if that's not the case, and where that validation should occur.

RFC @whitlockjc