### PR TITLE
add uuid format validator

### DIFF
--- a/lib/validation/format-validators.js
+++ b/lib/validation/format-validators.js
@@ -25,6 +25,7 @@
 'use strict';
 
 var _ = require('lodash');
+var validator = require('validator');
 
 function returnTrue () {
   return true;
@@ -35,6 +36,10 @@ module.exports.int32 = module.exports.int64 = function (val) {
   // check prior to validating this format.
   return _.isNumber(val) && val % 1 === 0;
 };
+
+module.exports.uuid = function (val) {
+  return validator.isUUID(val);
+}
 
 // These format validators will always return 'true' because they are already type valid and there are no constraints
 // on the format that would produce an invalid value.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "path-to-regexp": "^1.2.1",
     "swagger-methods": "^1.0.0",
     "swagger-schema-official": "2.0.0-bab6bed",
+    "validator": "^5.2.0",
     "z-schema": "^3.16.1"
   }
 }

--- a/test/test-format-validators.js
+++ b/test/test-format-validators.js
@@ -201,4 +201,62 @@ describe('format validators', function () {
       assert.ok(goodParamValue.valid);
     });
   });
+
+  describe('int32', function () {
+    var badParamValue;
+    var goodParamValue;
+
+    before(function (done) {
+      var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
+
+      cSwaggerDoc.paths['/pet/findByStatus'].get.parameters.push({
+        name: 'uuid',
+          in: 'query',
+        type: 'string',
+        format: 'uuid'
+      });
+
+      // Test the format validator using parameter validation
+      Sway.create({definition: cSwaggerDoc})
+        .then(function (api) {
+            badParamValue = api.getOperation('/pet/findByStatus', 'get').getParameter('uuid').getValue({
+            query: {
+              uuid: 'asdf'
+            }
+          });
+          goodParamValue = api.getOperation('/pet/findByStatus', 'get').getParameter('uuid').getValue({
+            query: {
+              uuid: '9b299a97-858c-40c7-bbd1-8ac3987db564'
+            }
+          });
+        })
+        .then(done, done);
+    });
+
+    it('bad value', function () {
+      var error = badParamValue.error;
+
+      assert.ok(!badParamValue.valid);
+      assert.ok(!_.isUndefined(badParamValue.value));
+      assert.equal(badParamValue.raw, 'asdf');
+      assert.equal(error.message, 'Value failed JSON Schema validation');
+      assert.equal(error.code, 'SCHEMA_VALIDATION_FAILED');
+      assert.ok(error.failedValidation);
+      assert.deepEqual(error.errors, [
+        {
+          code: 'INVALID_FORMAT',
+          message: 'Object didn\'t pass validation for format uuid: asdf',
+          params: [
+            'uuid',
+            'asdf'
+          ],
+          path: []
+        }
+      ]);
+    });
+
+    it('good value', function () {
+      assert.ok(goodParamValue.valid);
+    });
+  });
 });

--- a/test/test-format-validators.js
+++ b/test/test-format-validators.js
@@ -202,7 +202,7 @@ describe('format validators', function () {
     });
   });
 
-  describe('int32', function () {
+  describe('uuid', function () {
     var badParamValue;
     var goodParamValue;
 


### PR DESCRIPTION
Adds validation for string format "uuid". 

Though it's not defined in the spec, it's referenced by the Swagger docs and will be a common use case for identifying API resources.