### PR TITLE
Allow array parameter default value

### DIFF
--- a/lib/types/parameter-value.js
+++ b/lib/types/parameter-value.js
@@ -165,7 +165,9 @@ function ParameterValue (parameterObject, raw) {
 
             // If there is still no value and there are no errors, use the default value if available (no coercion)
             if (_.isUndefined(processedValue) && _.isUndefined(error)) {
-              if (schema.type === 'array') {
+              if (!_.isUndefined(schema.default)) {
+                processedValue = schema.default;
+              } else if (schema.type === 'array') {
                 if (_.isArray(schema.items)) {
                   processedValue = _.reduce(schema.items, function (items, item) {
                     items.push(item.default);
@@ -181,10 +183,6 @@ function ParameterValue (parameterObject, raw) {
                   if (!_.isUndefined(schema.items) && !_.isUndefined(schema.items.default)) {
                     processedValue = [schema.items.default];
                   }
-                }
-              } else {
-                if (!_.isUndefined(schema.default)) {
-                  processedValue = schema.default;
                 }
               }
             }


### PR DESCRIPTION
Previously _schema.default_ tag for _schema.type_ === array was never processed and only _schema.items.default_ were usable.
