### PR TITLE
Use definitionsFullyResolved when lookup up consumes/produces propert…

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -62,14 +62,14 @@ function Operation (pathObject, method, definition, definitionFullyResolved, pat
   var that = this;
 
   // Assign local properties
-  this.consumes = definition.consumes || pathObject.api.consumes || [];
+  this.consumes = definitionFullyResolved.consumes || pathObject.api.consumes || [];
   this.definition = _.cloneDeep(definition); // Clone so we do not alter the original
   this.definitionFullyResolved = _.cloneDeep(definitionFullyResolved); // Clone so we do not alter the original
   this.method = method;
   this.parameterObjects = []; // Computed below
   this.pathObject = pathObject;
   this.pathToDefinition = pathToDefinition;
-  this.produces = definition.produces || pathObject.api.produces || [];
+  this.produces = definitionFullyResolved.produces || pathObject.api.produces || [];
   this.ptr = JsonRefs.pathToPtr(pathToDefinition);
 
   // Assign local properties from the Swagger definition properties


### PR DESCRIPTION
Use definitionsFullyResolved when lookup up consumes/produces properties - fixes issue when using split definition files - ref [Issue 92](https://github.com/apigee-127/sway/issues/92)
