### PR TITLE
Add x-ignore-validate option to request validation

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -246,10 +246,15 @@ Operation.prototype.validateRequest = function (req) {
 
   // Validate the parameters
   _.each(this.getParameters(), function (param) {
-    var paramValue = param.getValue(req);
+    var paramValue;
     var vErr;
 
-    if (!paramValue.valid) {
+    // if 'x-ignore-validate' is set for this parameter, skip validation
+    if (!param.definition['x-ignore-validate']) {
+        paramValue = param.getValue(req);
+    }
+
+    if (paramValue && !paramValue.valid) {
       vErr = {
         code: 'INVALID_REQUEST_PARAMETER',
         errors: paramValue.error.errors || [

--- a/test/test-operation.js
+++ b/test/test-operation.js
@@ -407,6 +407,23 @@ describe('Operation', function () {
           ]);
         });
 
+        it('should not return an error for skipped parameters', function () {
+          var operation = swaggerApiRelativeRefs.getOperation('/pet/{petId}/uploadImage', 'post');
+
+          operation.getParameters()[0].definition['x-ignore-validate'] = true;
+          var results = operation.validateRequest({
+            url: '/v2/pet/notANumber/uploadImage',
+            headers: {
+              'content-type': 'multipart/form-data'
+            },
+            body: {},
+            files: {}
+          });
+
+          assert.equal(results.errors.length, 0);
+          assert.equal(results.warnings.length, 0);
+        });
+
         it('should not return an error for valid parameters', function () {
           var operation = swaggerApiRelativeRefs.getOperation('/pet/{petId}', 'post');
           var results = operation.validateRequest({


### PR DESCRIPTION
* This option allows specified parameters to bypass validation.

We are working on a project that uses a custom validator for certain parameters defined in our swagger definition.  Adding this option allows us to tell sway to skip validation for parameters that have already validated.