### PR TITLE
fixed bug with parsing a single-value array

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -208,7 +208,7 @@ var convertValue = module.exports.convertValue = function (schema, options, valu
   }
 
   // Attempt to parse the string as JSON if the type is array or object
-  if (['array', 'object'].indexOf(type) > -1) {
+  if (['array', 'object'].indexOf(type) > -1 && pType === 'string') {
     try {
       value = JSON.parse(value);
     } catch (err) {


### PR DESCRIPTION
I would love to follow the guidelines for contributing to the repository, but I don't have the time to figure it out - it's definitely non-trivial.  I've already spent several hours tracking down this issue.  If you want me to resubmit as a bug - fine.

This is a pretty simple bug.  See [this project](https://github.com/ocelotconsulting/reproduce-sway-bug).  Run the project, then this CURL:

```
curl -v -X PUT http://localhost:10010/hello -H 'Content-Type: application/json' -d '["123"]'
```

The response is this confusing JSON:

``` javascript
{
  "message": "Validation errors",
  "errors": [
    {
      "code": "INVALID_REQUEST_PARAMETER",
      "errors": [
        {
          "code": "INVALID_TYPE",
          "params": [
            "array",
            "integer"
          ],
          "message": "Expected type array but found type integer",
          "path": []
        }
      ],
      "in": "body",
      "message": "Invalid parameter (body): Value failed JSON Schema validation",
      "name": "body",
      "path": [
        "paths",
        "/hello",
        "put",
        "parameters",
        "0"
      ]
    }
  ]
}
```

If you define a POST/PUT endpoint that accepts a string array body, sway will attempt to JSON.parse(...) that body (which has already been parsed by body-parser).  If it fails there's no issue, but if it succeeds the body is replaced.  Presumably the author assumed that JSON parsing would fail unless the value was a string... but that's not the case thanks to the crazy rules of JavaScript type coercion.

To illustrate why, try this from your favorite REPL:

``` javascript
JSON.parse(['foo']) // error as you would expect
JSON.parse(['123']) // no error! returns the number 123
JSON.parse(['123','456']) // error 
```
Making sure that what you're trying to parse is actually a string fixes the issue.
