### PR TITLE
allow missing optional params

### DIFF
--- a/lib/types/parameter.js
+++ b/lib/types/parameter.js
@@ -138,20 +138,32 @@ Parameter.prototype.getValue = function (req) {
     // value since the JSON Schema for formData parameters does not allow a type of 'object'.
     if (type === 'file') {
       if (_.isUndefined(req.files)) {
-        throw new Error('req.files must be provided for \'formData\' parameters of type \'file\'');
+        if (this.required) {
+          throw new Error('req.files must be provided for \'formData\' parameters of type \'file\'');
+        } else {
+          break;
+        }
       }
 
       value = req.files[this.name];
     } else {
       if (_.isUndefined(req.body)) {
-        throw new Error('req.body must be provided for \'formData\' parameters');
+        if (this.required) {
+          throw new Error('req.body must be provided for \'formData\' parameters');
+        } else {
+          break;
+        }
       }
       value = req.body[this.name];
     }
     break;
   case 'header':
     if (_.isUndefined(req.headers)) {
-      throw new Error('req.headers must be provided for \'header\' parameters');
+      if (this.required) {
+        throw new Error('req.headers must be provided for \'header\' parameters');
+      } else {
+        break;
+      }
     }
 
     value = helpers.getHeaderValue(req.headers, this.name);
@@ -172,7 +184,11 @@ Parameter.prototype.getValue = function (req) {
     break;
   case 'query':
     if (_.isUndefined(req.query)) {
-      throw new Error('req.query must be provided for \'query\' parameters');
+      if (this.required) {
+        throw new Error('req.query must be provided for \'query\' parameters');
+      } else {
+        break;
+      }
     }
 
     value = _.get(req.query, this.name);

--- a/test/browser/documents/2.0/swagger.yaml
+++ b/test/browser/documents/2.0/swagger.yaml
@@ -183,7 +183,7 @@ paths:
         - name: "name"
           in: "formData"
           description: "Updated name of the pet"
-          required: false
+          required: true
           type: "string"
         - name: "status"
           in: "formData"
@@ -206,7 +206,7 @@ paths:
       - name: "api_key"
         in: "header"
         description: ""
-        required: false
+        required: true
         type: "string"
         default: ""
       responses:
@@ -238,7 +238,7 @@ paths:
       - name: "file"
         in: "formData"
         description: "file to upload"
-        required: false
+        required: true
         type: "file"
       responses:
         200:

--- a/test/browser/documents/2.0/swagger.yaml
+++ b/test/browser/documents/2.0/swagger.yaml
@@ -209,6 +209,12 @@ paths:
         required: true
         type: "string"
         default: ""
+      - name: "optional_header"
+        in: "header"
+        description: ""
+        required: false
+        type: "string"
+        default: ""
       responses:
         400:
           description: "Invalid pet value"
@@ -239,6 +245,11 @@ paths:
         in: "formData"
         description: "file to upload"
         required: true
+        type: "file"
+      - name: "optionalFile"
+        in: "formData"
+        description: "file to upload"
+        required: false
         type: "file"
       responses:
         200:

--- a/test/test-operation.js
+++ b/test/test-operation.js
@@ -857,7 +857,9 @@ describe('Operation', function () {
               'content-type': 'multipart/form-data'
             },
             body: {},
-            files: {}
+            files: {
+              'file': 'fake file'
+            }
           });
 
           assert.equal(results.warnings.length, 0);

--- a/test/test-parameter.js
+++ b/test/test-parameter.js
@@ -195,7 +195,7 @@ describe('Parameter', function () {
         });
       });
 
-      describe('formData (file)', function () {
+      describe('formData (file) - required', function () {
         var parameter;
 
         before(function () {
@@ -227,7 +227,23 @@ describe('Parameter', function () {
         });
       });
 
-      describe('formData (not file)', function () {
+      describe('formData (file) - optional', function () {
+        var parameter;
+
+        before(function () {
+          parameter = swaggerApi.getOperation('/pet/{petId}/uploadImage', 'post').getParameter('optionalFile');
+        });
+
+        it('missing req.files', function () {
+          try {
+            parameter.getValue({});
+          } catch (err) {
+            helpers.shouldNotHadFailed();
+          }
+        });
+      });
+
+      describe('formData (not file) - required', function () {
         var parameter;
 
         before(function () {
@@ -260,7 +276,23 @@ describe('Parameter', function () {
         });
       });
 
-      describe('header', function () {
+      describe('formData (not file) - optional', function () {
+        var parameter;
+
+        before(function () {
+          parameter = swaggerApi.getOperation('/pet/{petId}', 'post').getParameter('status');
+        });
+
+        it('missing req.body', function () {
+          try {
+            parameter.getValue({});
+          } catch (err) {
+            helpers.shouldNotHadFailed
+          }
+        });
+      });
+
+      describe('header - required', function () {
         var parameter;
 
         before(function () {
@@ -303,6 +335,22 @@ describe('Parameter', function () {
 
           // Change it back
           parameter.name = 'api_key';
+        });
+      });
+
+      describe('header - optional', function () {
+        var parameter;
+
+        before(function () {
+          parameter = swaggerApi.getOperation('/pet/{petId}', 'delete').getParameter('optional_header');
+        });
+
+        it('missing req.headers', function () {
+          try {
+            parameter.getValue({});
+          } catch (err) {
+            helpers.shouldNotHadFailed
+          }
         });
       });
 


### PR DESCRIPTION
Fix #129 

When a parameter is marked as `required: false`, sway should not throw an exception if it is missing.

Except for parameters that are `in: path`, those are still always required.