### PR TITLE
Remove method check for operation consumes validation

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -243,8 +243,8 @@ Operation.prototype.validateRequest = function (req) {
     warnings: []
   };
 
-  // Validate the Content-Type but only for POST and PUT (The rest do not have bodies)
-  if (['post', 'put'].indexOf(this.method) > -1) {
+  // Validate the Content-Type if there is a set of expected consumes
+  if (this.consumes.length > 0) {
     helpers.validateContentType(helpers.getContentType(req.headers), this.consumes, results);
   }
 

--- a/test/test-operation.js
+++ b/test/test-operation.js
@@ -229,6 +229,31 @@ describe('Operation', function () {
           }
         };
 
+        describe('operation level consumes - ignore when empty', function () {
+          var operation; 
+
+          before(function () {
+            // this path+op doesn't specify 'consumes'
+            operation = swaggerApiRelativeRefs.getOperation('/pet/findByStatus', 'get');
+          });
+          
+          it('should not return an unsupported content-type error', function () {
+            var request = {
+              url: '/pet/findByStatus',
+              query: {
+                'status': 'sold'
+              },
+              headers: {
+                'content-type': 'application/json' // extraneous content-type header
+              }
+            };
+            var results = operation.validateRequest(request);
+
+            assert.equal(results.warnings.length, 0);
+            assert.equal(results.errors.length, 0);
+          });
+        });
+
         describe('operation level consumes', function () {
           var operation;
 


### PR DESCRIPTION
Fix #134 

Removes the HTTP method check entirely but replaces it with a conditional that only allows `content-type` validation when the operation `consumes` is specified. 

Without the replacement check, other tests failed where the `consumes` wasn't specified for an operation but the `getContentType` [helper](https://github.com/apigee-127/sway/blob/master/lib/helpers.js#L350) adds a default `content-type` header, creating a conflict.