### PR TITLE
default response from getResponse

### DIFF
--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -190,9 +190,16 @@ Operation.prototype.getResponse = function (statusCode) {
     statusCode = statusCode.toString();
   }
 
-  return _.find(this.getResponses(), function (responseObject) {
-    return responseObject.statusCode === statusCode;
-  });
+  var response =  _.find(this.getResponses(), function (responseObject) {
+     return responseObject.statusCode === statusCode;
+   });
+
+  if (typeof myVar === 'undefined') {
+   response =  _.find(this.getResponses(), function (responseObject) {
+     return responseObject.statusCode === 'default';
+   });
+  }
+  return response;
 };
 
 /**

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -194,7 +194,7 @@ Operation.prototype.getResponse = function (statusCode) {
      return responseObject.statusCode === statusCode;
    });
 
-  if (typeof myVar === 'undefined') {
+  if (typeof response === 'undefined') {
    response =  _.find(this.getResponses(), function (responseObject) {
      return responseObject.statusCode === 'default';
    });


### PR DESCRIPTION
Fixes #166

Return default response from getResponse if getResponses does not have a matching status code.