### PR TITLE
Fix 'create' function return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ declare interface CreateOptions {
  * @param options - The options for loading the definition(s)
  * @returns The promise
  */
-declare function create(options: CreateOptions): Promise;
+declare function create(options: CreateOptions): Promise<SwaggerApi>;
 
 /**
  * Function used for custom validation of Swagger documents


### PR DESCRIPTION
I have come across the issue where you were planning to auto generate the types, but until you can get that sorted, fixing the type for `create` function that was causing typescript compiler to fail.