### PR TITLE
Fix API docs typo

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -803,7 +803,7 @@ Sway.create({
   definition: 'https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/petstore.yaml'
 })
 .then(function (apiDefinition) {
-  console.log('Documentation URL: ', api.documentationUrl);
+  console.log('Documentation URL: ', apiDefinition.documentationUrl);
 }, function (err) {
   console.error(err.stack);
 });


### PR DESCRIPTION
Correct variable name in Sway.create example